### PR TITLE
Remove update alert bubble

### DIFF
--- a/ckanext/iati/theme/templates/header.html
+++ b/ckanext/iati/theme/templates/header.html
@@ -14,11 +14,6 @@
 
       </div>
   {% endif %}
-  <div class="alert" style="text-align: center">
-    <strong>The Registry was updated on October 12th. The upgrade included changes to API functionality.
-      <a href="http://www.aidtransparency.net/news/important-changes-to-the-iati-registry-api">More information here</a>.
-    </strong>
-  </div>
   <a href="#content" class="hide">{{ _('Skip to primary content') }}</a>
   <header id="header">
     <div class="container">


### PR DESCRIPTION
This removes an alert bubble relating to the update on October 12th since it is now a fair while since the update occurred, making the bubble unnecessary.

Tagging @dalepotter for secondary confirmation to remove this alert.