### PR TITLE
Add 1.05 and 2.02 to valid versions

### DIFF
--- a/ckanext/iati/lists.py
+++ b/ckanext/iati/lists.py
@@ -1,7 +1,7 @@
 from countries import COUNTRIES
 
 IATI_STANDARD_VERSIONS = [
-    '1.01', '1.02', '1.03', '1.04', '2.01',
+    '1.01', '1.02', '1.03', '1.04', '1.05', '2.01', '2.02'
 ]
 
 FILE_TYPES = [


### PR DESCRIPTION
Versions 1.05 and 2.02 are also valid versions of the IATI Standard.  The main config file will also need to be updated.