### PR TITLE
[#130] Fix failed publisher deletion bug

### DIFF
--- a/ckanext/iati/theme/templates/organization/confirm_delete.html
+++ b/ckanext/iati/theme/templates/organization/confirm_delete.html
@@ -1,0 +1,17 @@
+{% ckan_extends %}
+
+{% block main_content %}
+  <section class="module span6 offset3">
+    <div class="module-content">
+      {% block form %}
+        <p>{{ _('Are you sure you want to delete the publisher {name}?').format(name=c.group_dict.name) }}</p>
+        <p class="form-actions">
+          <form id="organization-confirm-delete-form" action="{{ '/publisher/delete/' + c.group_dict.name }}" method="post">
+            <button class="btn" type="submit" name="cancel" >{{ _('Cancel') }}</button>
+            <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Delete') }}</button>
+          </form>
+        </p>
+      {% endblock %}
+    </div>
+  </section>
+{% endblock %}

--- a/ckanext/iati/theme/templates/organization/confirm_delete_member.html
+++ b/ckanext/iati/theme/templates/organization/confirm_delete_member.html
@@ -1,0 +1,18 @@
+{% ckan_extends %}
+
+{% block main_content %}
+  <section class="module span6 offset3">
+    <div class="module-content">
+      {% block form %}
+        <p>{{ _('Are you sure you want to delete member {name}?').format(name=c.user_dict.name) }}</p>
+        <p class="form-actions">
+          <form action="{{ '/publisher/member_delete/' + c.group_id }}" method="post">
+            <input type="hidden" name="user" value="{{ c.user_id }}" />
+            <button class="btn" type="submit" name="cancel" >{{ _('Cancel') }}</button>
+            <button class="btn btn-primary" type="submit" name="delete" >{{ _('Confirm Delete') }}</button>
+          </form>
+        </p>
+      {% endblock %}
+    </div>
+  </section>
+{% endblock %}


### PR DESCRIPTION
Confirming the deletion of publishers and publisher members failed because the respective forms posted the confirmation to `/organization/delete/{publisher-name}` when they needed to submit to `/publisher/delete/{publisher-name}`. The new forms post to the correct URL and the deletions are confirmed and processed by CKAN. 