### PR TITLE
[#125] Standardise format of `data_updated`

### DIFF
--- a/ckanext/iati/archiver.py
+++ b/ckanext/iati/archiver.py
@@ -226,9 +226,8 @@ def archive_package(package_id, context, consecutive_errors=0):
 
         # Check dates
         if last_updated_date:
-            format = ('%Y-%m-%d %H:%M' if (last_updated_date.hour and
-                      last_updated_date.minute) else '%Y-%m-%d')
-            new_extras['data_updated'] = last_updated_date.strftime(format)
+            fmt = '%Y-%m-%d %H:%M:%S'
+            new_extras['data_updated'] = last_updated_date.strftime(fmt)
         else:
             new_extras['data_updated'] = None
 


### PR DESCRIPTION
Currently, the seconds from `last-updated-datetime` are always discarded, meaning `data_updated` is pretty much always at least a bit wrong.

Also, if the hour and minute are either zero or not present, the time is discarded and only a date is used. Using a standardised timestamp format here seems preferable.