### PR TITLE
Set version regardless of filetype

### DIFF
--- a/ckanext/iati/archiver.py
+++ b/ckanext/iati/archiver.py
@@ -187,10 +187,7 @@ def archive_package(package_id, context, consecutive_errors=0):
 
         new_extras = {}
         # IATI standard version (iati_version extra)
-        if is_activity_package:
-            xpath = '/iati-activities/@version'
-        else:
-            xpath = '/iati-organisations/@version'
+        xpath = '/iati-activities/@version | /iati-organisations/@version'
 
         version = tree.xpath(xpath)
 	log.info(version)


### PR DESCRIPTION
The IATI version metadata is independent of the filetype metadata.
So even if the filetype is wrong, we can (and should) still set the
version.

Refs #117.