### PR TITLE
Fix regex that strips the generated-datetime

### DIFF
--- a/ckanext/iati/archiver.py
+++ b/ckanext/iati/archiver.py
@@ -401,7 +401,7 @@ def download(context, resource, url_timeout=URL_TIMEOUT,
     # update the resource metadata in CKAN if the resource has changed
     # IATI: remove generated time tags before calculating the hash
     content = open(saved_file, 'r').read()
-    content = re.sub('generated-datetime="(.*)"', '', content)
+    content = re.sub(r'generated-datetime="[^"]+"', '', content)
 
     resource_hash = hashlib.sha1()
     resource_hash.update(content)

--- a/ckanext/iati/archiver.py
+++ b/ckanext/iati/archiver.py
@@ -400,7 +400,8 @@ def download(context, resource, url_timeout=URL_TIMEOUT,
 
     # update the resource metadata in CKAN if the resource has changed
     # IATI: remove generated time tags before calculating the hash
-    content = open(saved_file, 'r').read()
+    with open(saved_file, 'r') as f:
+        content = f.read()
     content = re.sub(r'generated-datetime="[^"]+"', '', content)
 
     resource_hash = hashlib.sha1()


### PR DESCRIPTION
This forces the regex to be non-greedy.

Fixes #152.