### PR TITLE
Remove unused code from pending publishers dashboard

### DIFF
--- a/ckanext/iati/controllers/publisher.py
+++ b/ckanext/iati/controllers/publisher.py
@@ -22,6 +22,4 @@ class PublisherController(BaseController):
         return render('organization/members_read.html')
 
     def dashboard_pending_organizations(self):
-        context = {'for_view': True, 'user': c.user or c.author, 'auth_user_obj': c.userobj}
-        data_dict = {'user_obj': c.userobj}
         return render('user/dashboard_pending_organizations.html')

--- a/ckanext/iati/controllers/publisher.py
+++ b/ckanext/iati/controllers/publisher.py
@@ -24,5 +24,4 @@ class PublisherController(BaseController):
     def dashboard_pending_organizations(self):
         context = {'for_view': True, 'user': c.user or c.author, 'auth_user_obj': c.userobj}
         data_dict = {'user_obj': c.userobj}
-        # self._setup_template_variables(context, data_dict)
         return render('user/dashboard_pending_organizations.html')


### PR DESCRIPTION
This pull request removes unused variables and code from the pending publishers dashboard controller. The controller just renders a template, so the variable assignations are unnecessary.