### PR TITLE
Add 2.03 as a valid version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ like ``ckan.site_id``, ``solr_url``, etc are not included)::
     # Subject of the email sent to publishers when activated, default is 'IATI Registry Publisher Activation'
     #iati.publisher_activation_email_subject=
 
-    # Allowed values for the IATI Standard Version (iati_version) field, default is '1.01 1.02 1.03 1.04 1.05 2.01 2.02'
+    # Allowed values for the IATI Standard Version (iati_version) field, default is '1.01 1.02 1.03 1.04 1.05 2.01 2.02 2.03'
     #iati.standard_versions
 
     # Set a user agent string used by ckanext-archiver when making requests

--- a/ckanext/iati/lists.py
+++ b/ckanext/iati/lists.py
@@ -1,7 +1,7 @@
 from countries import COUNTRIES
 
 IATI_STANDARD_VERSIONS = [
-    '1.01', '1.02', '1.03', '1.04', '1.05', '2.01', '2.02'
+    '1.01', '1.02', '1.03', '1.04', '1.05', '2.01', '2.02', '2.03'
 ]
 
 FILE_TYPES = [


### PR DESCRIPTION
As prep for `2.03`, a PR containing changes that adds this as a known valid version of the IATI Standard.