### PR TITLE
Add notice re Registry read-only mode

### DIFF
--- a/ckanext/iati/theme/templates/header.html
+++ b/ckanext/iati/theme/templates/header.html
@@ -14,6 +14,10 @@
 
       </div>
   {% endif %}
+  <div class="alert" style="text-align: center">
+    <strong>Important: </strong>The Registry will be in read-only mode from Friday 23rd March at 00:00 GMT until Monday 26th March 18:00 GMT.<br/>
+    <a href="https://discuss.iatistandard.org/t/iati-registry-migration-read-only-access-friday-23-monday-26-march/1261">More information here</a>.
+  </div>
   <a href="#content" class="hide">{{ _('Skip to primary content') }}</a>
   <header id="header">
     <div class="container">


### PR DESCRIPTION
As part of the supplier migration process, this PR adds a notice to inform users that the site will be in e read-only mode for a period of time.